### PR TITLE
Add 'sudo' for default Ruby install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Shows a project's CocoaPod dependency graph.
 
 Using the default Ruby install will require you to use sudo when installing gems. Install it by performing the following command:
 
-    $ sudo gem install cocoapods-dependencies
+    $ [sudo] gem install cocoapods-dependencies
 
 ## Usage
 


### PR DESCRIPTION
Minor update to README instructions. `sudo` will avoid the following error to new users -

```
ERROR:  While executing gem ... (Gem::FilePermissionError)
You don't have write permissions for the /Library/Ruby/Gems/2.0.0 directory.
```
