### PR TITLE
Fixes a crash which occur with CocoaPods 0.35

### DIFF
--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -63,7 +63,7 @@ module Pod
           specs = analyzer.analyze(@repo_update).specs_by_target.values.flatten(1)
           config.integrate_targets = integrate_targets
 
-          lockfile = Lockfile.generate(podfile, specs)
+          lockfile = Lockfile.generate(podfile, specs, {})
           pods = lockfile.to_hash['PODS']
         end
       end


### PR DESCRIPTION
`pod dependencies` was crashing with CocoaPods 0.35. This will fix this crash:

Crash log:

```
ArgumentError - wrong number of arguments (2 for 3)
/Library/Ruby/Gems/2.0.0/gems/cocoapods-core-0.35.0/lib/cocoapods-core/lockfile.rb:362:in `generate'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-dependencies-0.3.2/lib/pod/command/dependencies.rb:66:in `dependencies'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-dependencies-0.3.2/lib/pod/command/dependencies.rb:49:in `block in run'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.35.0/lib/cocoapods/user_interface.rb:91:in `title'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-dependencies-0.3.2/lib/pod/command/dependencies.rb:47:in `run'
/Library/Ruby/Gems/2.0.0/gems/claide-0.7.0/lib/claide/command.rb:271:in `run'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.35.0/lib/cocoapods/command.rb:45:in `run'
/Library/Ruby/Gems/2.0.0/gems/cocoapods-0.35.0/bin/pod:43:in `<top (required)>'
/usr/bin/pod:23:in `load'
/usr/bin/pod:23:in `<main>'
```
