### PR TITLE
Add graphviz and image output options.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cocoapods-dependencies (0.4.1)
-      ruby-graphviz
+      ruby-graphviz (~> 1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,13 @@ PATH
   remote: .
   specs:
     cocoapods-dependencies (0.4.1)
+      ruby-graphviz
 
 GEM
   remote: https://rubygems.org/
   specs:
     rake (10.2.2)
+    ruby-graphviz (1.2.2)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -14,5 +14,9 @@ $ [sudo] gem install cocoapods-dependencies
 ## Usage
 
 ```bash
-$ pod dependencies [PODSPEC]
+$ pod dependencies [PODSPEC] [--graphviz] [--image]
 ```
+
+Use the `--graphviz` option to generate `<podspec name>.gv` or `Podfile.gv` containing the dependency graph in graphviz format.
+
+Use the `--image` option to generate `<podsepc name>.png` or `Podfile.png` containing a rendering of the dependency graph.

--- a/cocoapods_dependencies.gemspec
+++ b/cocoapods_dependencies.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  
+  spec.add_dependency "ruby-graphviz"
 end

--- a/cocoapods_dependencies.gemspec
+++ b/cocoapods_dependencies.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   
-  spec.add_dependency "ruby-graphviz"
+  spec.add_dependency "ruby-graphviz", "~> 1.2"
 end

--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -14,8 +14,8 @@ module Pod
         [
           ['--ignore-lockfile', 'Whether the lockfile should be ignored when calculating the dependency graph'],
           ['--repo-update', 'Fetch external podspecs and run `pod repo update` before calculating the dependency graph'],
-          ['--graphviz', 'Outputs the dependency graph in Graphviz format to Podfile.gv'],
-          ['--image', 'Outputs the dependency graph as an image to Podfile.png']
+          ['--graphviz', 'Outputs the dependency graph in Graphviz format to <podspec name>.gv or Podfile.gv'],
+          ['--image', 'Outputs the dependency graph as an image to <podsepc name>.png or Podfile.png']
         ].concat(super)
       end
 

--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -1,6 +1,3 @@
-require 'graphviz'
-require 'yaml'
-
 module Pod
   class Command
     class Dependencies < Command
@@ -15,7 +12,7 @@ module Pod
           ['--ignore-lockfile', 'Whether the lockfile should be ignored when calculating the dependency graph'],
           ['--repo-update', 'Fetch external podspecs and run `pod repo update` before calculating the dependency graph'],
           ['--graphviz', 'Outputs the dependency graph in Graphviz format to <podspec name>.gv or Podfile.gv'],
-          ['--image', 'Outputs the dependency graph as an image to <podsepc name>.png or Podfile.png']
+          ['--image', 'Outputs the dependency graph as an image to <podsepc name>.png or Podfile.png'],
         ].concat(super)
       end
 
@@ -51,6 +48,8 @@ module Pod
       end
 
       def run
+        require 'graphviz'
+        require 'yaml'
         graphviz_image_output if @produce_image_output
         graphviz_dot_output if @produce_graphviz_output
         yaml_output
@@ -109,7 +108,7 @@ module Pod
           graph = GraphViz::new(output_file_basename, :type => :digraph)
           root = graph.add_node(output_file_basename)
           
-          if !@podspec
+          unless @podspec
             podfile_dependencies.each do |pod|
               pod_node = graph.add_node(pod)
               graph.add_edge(root, pod_node)
@@ -131,7 +130,7 @@ module Pod
       # Truncates the input string after a pod's name removing version requirements, etc.
       def sanitized_pod_name(name)
         match = /([\w_\/]+)( \(.*\))?/.match(name)
-        match ? match[1] : "#{name}"
+        match ? match[1] : name
       end
       
       # Returns a Set of Strings of the names of dependencies specified in the Podfile. 
@@ -146,7 +145,7 @@ module Pod
       
       # Returns a [String: [String]] containing resolved mappings from the name of a pod to an array of the names of its dependencies.
       def pod_to_dependencies
-        dependencies.map { |d| d.is_a?(Hash) ? d : { d => [] } }.reduce(Hash[]) { |combined, individual| combined.merge!(individual) }
+        dependencies.map { |d| d.is_a?(Hash) ? d : { d => [] } }.reduce({}) { |combined, individual| combined.merge!(individual) }
       end
       
       # Basename to use for output files.

--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -1,3 +1,6 @@
+require 'graphviz'
+require 'yaml'
+
 module Pod
   class Command
     class Dependencies < Command
@@ -11,6 +14,8 @@ module Pod
         [
           ['--ignore-lockfile', 'Whether the lockfile should be ignored when calculating the dependency graph'],
           ['--repo-update', 'Fetch external podspecs and run `pod repo update` before calculating the dependency graph'],
+          ['--graphviz', 'Outputs the dependency graph in Graphviz format to Podfile.gv'],
+          ['--image', 'Outputs the dependency graph as an image to Podfile.png']
         ].concat(super)
       end
 
@@ -24,6 +29,8 @@ module Pod
         @podspec_name = argv.shift_argument
         @ignore_lockfile = argv.flag?('ignore-lockfile', false)
         @repo_update = argv.flag?('repo-update', false)
+        @produce_graphviz_output = argv.flag?('graphviz', false)
+        @produce_image_output = argv.flag?('image', false)
         super
       end
 
@@ -44,10 +51,9 @@ module Pod
       end
 
       def run
-        UI.title 'Dependencies' do
-          require 'yaml'
-          UI.puts dependencies.to_yaml
-        end
+        graphviz_image_output if @produce_image_output
+        graphviz_dot_output if @produce_graphviz_output
+        yaml_output
       end
 
       def dependencies
@@ -96,6 +102,71 @@ module Pod
         else
           config.sandbox
         end
+      end
+      
+      def graphviz_data
+        @graphviz ||= begin
+          graph = GraphViz::new(output_file_basename, :type => :digraph)
+          root = graph.add_node(output_file_basename)
+          
+          if !@podspec
+            podfile_dependencies.each do |pod|
+              pod_node = graph.add_node(pod)
+              graph.add_edge(root, pod_node)
+            end
+          end
+          
+          pod_to_dependencies.each do |pod, dependencies|
+            pod_node = graph.add_node(sanitized_pod_name(pod))
+            dependencies.each do |dependency|
+              dep_node = graph.add_node(sanitized_pod_name(dependency))
+              graph.add_edge(pod_node, dep_node)
+            end
+          end
+          
+          graph
+        end
+      end
+      
+      # Truncates the input string after a pod's name removing version requirements, etc.
+      def sanitized_pod_name(name)
+        match = /([\w_\/]+)( \(.*\))?/.match(name)
+        match ? match[1] : "#{name}"
+      end
+      
+      # Returns a Set of Strings of the names of dependencies specified in the Podfile. 
+      def podfile_dependencies
+        Set.new(podfile.target_definitions.values.map { |t| t.dependencies.map { |d| d.name } }.flatten)
+      end
+      
+      # Returns a [String] of the names of dependencies specified in the podspec.
+      def podspec_dependencies
+        @podspec.all_dependencies.map { |d| d.name }
+      end
+      
+      # Returns a [String: [String]] containing resolved mappings from the name of a pod to an array of the names of its dependencies.
+      def pod_to_dependencies
+        dependencies.map { |d| d.is_a?(Hash) ? d : { d => [] } }.reduce(Hash[]) { |combined, individual| combined.merge!(individual) }
+      end
+      
+      # Basename to use for output files.
+      def output_file_basename
+        return 'Podfile' unless @podspec_name
+        File.basename(@podspec_name, File.extname(@podspec_name))
+      end
+      
+      def yaml_output
+        UI.title 'Dependencies' do
+          UI.puts dependencies.to_yaml
+        end
+      end
+      
+      def graphviz_image_output
+        graphviz_data.output( :png => "#{output_file_basename}.png")
+      end
+      
+      def graphviz_dot_output
+        graphviz_data.output( :dot => "#{output_file_basename}.gv")
       end
 
     end


### PR DESCRIPTION
This adds some new output options to help visualize your dependency graphs.

Example output with `--image`: 
![examplelib](https://cloud.githubusercontent.com/assets/47840/8298138/b9b467b6-1932-11e5-935c-3312c9c67051.png)
