### PR TITLE
Fix plugin to work with passing podspecs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in cocoapods-dependencies.gemspec
 gemspec
+
+gem 'cocoapods', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,16 +7,79 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (2.3.5)
+    activesupport (4.2.10)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    claide (1.0.2)
+    cocoapods (1.3.1)
+      activesupport (>= 4.0.2, < 5)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.3.1)
+      cocoapods-deintegrate (>= 1.0.1, < 2.0)
+      cocoapods-downloader (>= 1.1.3, < 2.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-stats (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.2.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (~> 2.0.1)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.5.7)
+      nap (~> 1.0)
+      ruby-macho (~> 1.1)
+      xcodeproj (>= 1.5.1, < 2.0)
+    cocoapods-core (1.3.1)
+      activesupport (>= 4.0.2, < 6)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+    cocoapods-deintegrate (1.0.1)
+    cocoapods-downloader (1.1.3)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.0)
+    cocoapods-stats (1.0.0)
+    cocoapods-trunk (1.3.0)
+      nap (>= 0.8, < 2.0)
+      netrc (~> 0.11)
+    cocoapods-try (1.1.0)
+    colored2 (3.1.2)
+    concurrent-ruby (1.0.5)
+    escape (0.0.4)
+    fourflusher (2.0.1)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.0.3)
+    i18n (0.9.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.10.3)
+    molinillo (0.5.7)
+    nanaimo (0.2.3)
+    nap (1.1.0)
+    netrc (0.11.0)
     rake (10.4.2)
     ruby-graphviz (1.2.2)
+    ruby-macho (1.1.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    xcodeproj (1.5.2)
+      CFPropertyList (~> 2.3.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.2.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 1.3)
+  cocoapods (~> 1.0)
   cocoapods-dependencies!
   rake
 
 BUNDLED WITH
-   1.13.1
+   1.15.4

--- a/cocoapods_dependencies.gemspec
+++ b/cocoapods_dependencies.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "cocoapods", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   

--- a/cocoapods_dependencies.gemspec
+++ b/cocoapods_dependencies.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "cocoapods", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   

--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -38,14 +38,8 @@ module Pod
         if @podspec_name
           require 'pathname'
           path = Pathname.new(@podspec_name)
-          if path.exist?
-            @podspec = Specification.from_file(path)
-          else
-            @podspec = SourcesManager.
-              search(Dependency.new(@podspec_name)).
-              specification.
-              subspec_by_name(@podspec_name)
-          end
+          raise "Cannot find #{@podspec_name}." unless path.exist?
+          @podspec = Specification.from_file(path)
         end
         if (@produce_image_output || @produce_graphviz_output) && Executable.which('dot').nil?
           raise Informative, 'GraphViz must be installed and `dot` must be in ' \
@@ -73,7 +67,7 @@ module Pod
           end
 
           lockfile = Lockfile.generate(podfile, specs, {})
-          pods = lockfile.to_hash['PODS']
+          lockfile.to_hash['PODS']
         end
       end
 
@@ -81,13 +75,15 @@ module Pod
         @podfile ||= begin
           if podspec = @podspec
             platform = podspec.available_platforms.first
-            platform_name, platform_version = platform.name, platform.deployment_target.to_s
-            sources = SourcesManager.all.map(&:url)
+            platform_name = platform.name
+            platform_version = platform.deployment_target.to_s
+            source_urls = Config.instance.sources_manager.all.map(&:url).join(',').split(',')
             Podfile.new do
-              install! :cocoapods, integrate_targets: false
-              sources.each { |s| source s }
+              install! 'cocoapods', integrate_targets: false, warn_for_multiple_pod_sources: false
+              source_urls.each { |u| source(u) }
               platform platform_name, platform_version
               pod podspec.name, podspec: podspec.defined_in_file
+              target 'Dependencies'
             end
           else
             verify_podfile_exists!
@@ -138,11 +134,6 @@ module Pod
       # Returns a Set of Strings of the names of dependencies specified in the Podfile.
       def podfile_dependencies
         Set.new(podfile.target_definitions.values.map { |t| t.dependencies.map { |d| d.name } }.flatten)
-      end
-
-      # Returns a [String] of the names of dependencies specified in the podspec.
-      def podspec_dependencies
-        @podspec.all_dependencies.map { |d| d.name }
       end
 
       # Returns a [String: [String]] containing resolved mappings from the name of a pod to an array of the names of its dependencies.


### PR DESCRIPTION
executing `pod dependencies Some.podspec` was not working since the `SourcesManager` code has changed in latest CocoaPods. 

Also performs a couple of other cleanup tasks.