### PR TITLE
Feature - Added option (use-podfile-targets) that allows using the targets from the Podfile

### DIFF
--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -125,15 +125,7 @@ module Pod
           require 'graphviz'
           graph = GraphViz::new(output_file_basename, :type => :digraph)
 
-          unless @use_podfile_targets
-            root = graph.add_node(output_file_basename)
-            unless @podspec
-              podfile_dependencies.each do |pod|
-                pod_node = graph.add_node(pod)
-                graph.add_edge(root, pod_node)
-              end
-            end
-          else
+          if @use_podfile_targets
             unless @podspec
               podfile.target_definitions.values.each do |target|
                 target_node = graph.add_node(target.name.to_s)
@@ -143,6 +135,14 @@ module Pod
                     graph.add_edge(target_node, pod_node)
                   end
                 end
+              end
+            end
+          else
+            root = graph.add_node(output_file_basename)
+            unless @podspec
+              podfile_dependencies.each do |pod|
+                pod_node = graph.add_node(pod)
+                graph.add_edge(root, pod_node)
               end
             end
           end

--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -15,7 +15,7 @@ module Pod
           ['--repo-update', 'Fetch external podspecs and run `pod repo update` before calculating the dependency graph'],
           ['--graphviz', 'Outputs the dependency graph in Graphviz format to <podspec name>.gv or Podfile.gv'],
           ['--image', 'Outputs the dependency graph as an image to <podspec name>.png or Podfile.png'],
-          ['--use-real-targets', 'Uses the real targets from the Podfile'],
+          ['--use-podfile-targets', 'Uses targets from the Podfile'],
         ].concat(super)
       end
 
@@ -31,7 +31,7 @@ module Pod
         @repo_update = argv.flag?('repo-update', false)
         @produce_graphviz_output = argv.flag?('graphviz', false)
         @produce_image_output = argv.flag?('image', false)
-        @use_real_targets = argv.flag?('use-real-targets', false)
+        @use_podfile_targets = argv.flag?('use-podfile-targets', false)
         super
       end
 
@@ -125,7 +125,7 @@ module Pod
           require 'graphviz'
           graph = GraphViz::new(output_file_basename, :type => :digraph)
 
-          unless @use_real_targets
+          unless @use_podfile_targets
             root = graph.add_node(output_file_basename)
             unless @podspec
               podfile_dependencies.each do |pod|


### PR DESCRIPTION
Added option (use-podfile-targets) that allows using the real targets from the `Podfile` instead of `Podfile` as root node of the graph. Default is off.

Here is a short demo using [SDWebImage Tests project](https://github.com/rs/SDWebImage/tree/master/Tests):

#### use-podfile-targets option if off -> Podfile root node
`pod dependencies --image`

![podfile2](https://user-images.githubusercontent.com/154913/43960490-dd1e509a-9cba-11e8-8e4a-7cd549721532.png)

#### use-podfile-targets is on -> Tests and TestsMac root nodes
`pod dependencies --image --use-podfile-targets`

![podfile](https://user-images.githubusercontent.com/154913/43960523-f381c9d4-9cba-11e8-9d67-e307b1204656.png)
