### PR TITLE
Add option to filter subtrees based on regex pattern.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
 
 * None.  
 
+## 1.4.0 (2019-07-25)
+
+##### Enhancements
+
+* Add `--filter-pattern` flag that allows filtering targets and their subtrees
+  from the graphviz and image output.
+  [Brian Partridge](https://github.com/brianpartridge)
+
+##### Bug Fixes
+
+* None.
 
 ## 1.3.0 (2018-08-16)
 

--- a/lib/cocoapods_dependencies.rb
+++ b/lib/cocoapods_dependencies.rb
@@ -1,5 +1,5 @@
 module Pod
   module Dependencies
-    VERSION = '1.3.0'
+    VERSION = '1.4.0'
   end
 end


### PR DESCRIPTION
- Bump version to 1.4.0

I wanted an easy way to declutter the visual dependency graph generated by graphviz. This allows for specifying a regex and filtering out subtrees of dependencies so you can control the content in the graph.