### PR TITLE
Adding a --summary flag that prints all pods' dependencies and dependents

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cocoapods-dependencies (1.3.0)
+    cocoapods-dependencies (1.4.0)
       ruby-graphviz (~> 1.2)
 
 GEM
@@ -61,7 +61,9 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     rake (10.4.2)
-    ruby-graphviz (1.2.3)
+    rexml (3.2.5)
+    ruby-graphviz (1.2.5)
+      rexml
     ruby-macho (1.1.0)
     thread_safe (0.3.6)
     tzinfo (1.2.3)
@@ -82,4 +84,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.16.3
+   1.17.3

--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -15,12 +15,11 @@ module Pod
           ['--repo-update', 'Fetch external podspecs and run `pod repo update` before calculating the dependency graph'],
           ['--graphviz', 'Outputs the dependency graph in Graphviz format to <podspec name>.gv or Podfile.gv'],
           ['--image', 'Outputs the dependency graph as an image to <podspec name>.png or Podfile.png'],
-          ['--list', 'Outputs the dependencies in a format similar to that of a Podfile.lock'],
           ['--use-podfile-targets', 'Uses targets from the Podfile'],
           ['--ranksep', 'If you use --image command this command will be useful. The gives desired rank separation, in inches. Example --ranksep=.75, default .75'],
           ['--nodesep', 'It is same as [--ranksep] command. Minimum space between two adjacent nodes in the same rank, in inches.Example --nodesep=.25, default .25'],
           ['--filter-pattern', 'Filters out subtrees from pods with names matching the specified pattern from the --graphviz and --image output. Example --filter-pattern="Tests"'],
-          ['--summary', 'Get a dependency graph breakdown by number of inbound and outbound edges'],
+          ['--summary', 'For each Pod in the dependency graph, see number of dependencies and dependents, listed in tabular format'],
         ].concat(super)
       end
 
@@ -36,7 +35,6 @@ module Pod
         @repo_update = argv.flag?('repo-update', false)
         @produce_graphviz_output = argv.flag?('graphviz', false)
         @produce_image_output = argv.flag?('image', false)
-        @list = argv.flag?('list', false)
         @use_podfile_targets = argv.flag?('use-podfile-targets', false)
         @ranksep = argv.option('ranksep', '0.75')
         @nodesep = argv.option('nodesep', '0.25')
@@ -75,8 +73,11 @@ module Pod
         end
         graphviz_image_output if @produce_image_output
         graphviz_dot_output if @produce_graphviz_output
-        yaml_output if @list
-        summary_output if @summary
+        if @summary
+          summary_output
+        else
+          yaml_output
+        end
       end
 
       def dependencies


### PR DESCRIPTION
I'm working on a cocoapods related migration that requires a bottom up traversal of the cocoapods dependency DAG for my iOS app. To that end `pod dependencies --image` has been incredibly useful.

I added a `--summary` flag that spits out the number of dependencies and dependents for each Pod/Version sorted in the ascending order of dependencies (i.e. leaf nodes first) and descending order of dependents (nodes that impact other nodes the most).

I also feature flagged the YAML output under `--list`

Sample output:
![Screen Shot 2021-07-19 at 11 50 54 AM](https://user-images.githubusercontent.com/4279885/126211750-bdf861e6-8579-4f8f-bd6c-1884eb3a69c6.png)

I'm also thinking about adding this table to SQLite and giving the user the option to write SQL queries agains the DAG data but that might be overkill. 