### PR TITLE
optimize graph and enable sphine settings

### DIFF
--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -18,6 +18,7 @@ module Pod
           ['--use-podfile-targets', 'Uses targets from the Podfile'],
           ['--ranksep', 'If you use --image command this command will be useful. The gives desired rank separation, in inches. Example --ranksep=.75, default .75'],
           ['--nodesep', 'It is same as [--ranksep] command. Minimum space between two adjacent nodes in the same rank, in inches.Example --nodesep=.25, default .25'],
+          ['--splines', 'straight lines: https://graphviz.readthedocs.io/en/stable/manual.html#styling'],
           ['--filter-pattern', 'Filters out subtrees from pods with names matching the specified pattern from the --graphviz and --image output. Example --filter-pattern="Tests"'],
         ].concat(super)
       end
@@ -37,6 +38,7 @@ module Pod
         @use_podfile_targets = argv.flag?('use-podfile-targets', false)
         @ranksep = argv.option('ranksep', '0.75')
         @nodesep = argv.option('nodesep', '0.25')
+        @splines = argv.option('splines', 'ortho')
         @filter_pattern = argv.option('filter-pattern', nil)
         super
       end
@@ -129,7 +131,7 @@ module Pod
       def graphviz_data
         @graphviz ||= begin
           require 'graphviz'
-          graph = GraphViz::new(output_file_basename, :type => :digraph, :ranksep => @ranksep, :nodesep => @nodesep)
+          graph = GraphViz::new(output_file_basename, :type => :digraph, :ranksep => @ranksep, :nodesep => @nodesep, :splines => @splines)
 
           if @use_podfile_targets
             unless @podspec
@@ -213,7 +215,7 @@ module Pod
       end
 
       def graphviz_dot_output
-        graphviz_data.output( :conan => "#{output_file_basename}.gv")
+        graphviz_data.output( :canon => "#{output_file_basename}.gv")
       end
 
     end

--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -213,7 +213,7 @@ module Pod
       end
 
       def graphviz_dot_output
-        graphviz_data.output( :dot => "#{output_file_basename}.gv")
+        graphviz_data.output( :conan => "#{output_file_basename}.gv")
       end
 
     end

--- a/lib/pod/command/dependencies.rb
+++ b/lib/pod/command/dependencies.rb
@@ -132,6 +132,7 @@ module Pod
         @graphviz ||= begin
           require 'graphviz'
           graph = GraphViz::new(output_file_basename, :type => :digraph, :ranksep => @ranksep, :nodesep => @nodesep, :splines => @splines)
+          graph.node["shape"] = "box"
 
           if @use_podfile_targets
             unless @podspec


### PR DESCRIPTION
* [canon](https://graphviz.org/docs/outputs/canon/) export the exact same graph output but without coordination information  
* support [sphine](https://graphviz.org/docs/attrs/splines/) 
* change the default shape to box